### PR TITLE
Corrected text describing MNIST neural network.

### DIFF
--- a/docs/tex/tutorials/inference-networks.tex
+++ b/docs/tex/tutorials/inference-networks.tex
@@ -75,10 +75,10 @@ network's input, which is a batch of data points.
 x_ph = tf.placeholder(tf.float32, [M, 28 * 28])
 \end{lstlisting}
 
-We build a neural network using Keras.
-It takes a 28 by 28 pixel image and outputs a $10$-dimensional
-output, one for the mean (\texttt{mu}) and one for the standard
-deviation (\texttt{sigma}).
+We build a neural network using Keras consisting of two dense layers, one for the mean (\texttt{loc}) and one for the standard
+deviation (\texttt{scale}).
+Each dense layer takes a 28 by 28 pixel image and outputs $10$ values, one for each digit class.
+
 \begin{lstlisting}[language=Python]
 from edward.models import Normal
 from keras.layers import Dense


### PR DESCRIPTION
Previously, the tutorial text did not make the following clear:
(1) what things were the "mean" and what things were the "standard deviation".
(2) what the 10 dimensions were for.
(3) that in Edward's Normal function, loc parameter refers to mu and scale refers to sigma.